### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # llt-annotation_environment
 
-[![Version](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/badge_fury.png)](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/badge_fury)
 [![Dependencies](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/gemnasium.png)](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/gemnasium)
 [![Build Status](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/travis.png)](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/travis)
 [![Coverage](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/coveralls.png)](http://allthebadges.io/latin-language-toolkit/llt-annotation_environment/coveralls)


### PR DESCRIPTION
All badge links can be found in the README now **
Before this can be merged, we need to make sure that all badges we want to include work or otherwise get rid of them.

Closes #15

*\* Done with one command by the way: `gem_polish polish -ng latin-language-toolkit -b all`
