### PR TITLE
More flexible noRetrieval options in morph

### DIFF
--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -147,9 +147,11 @@ angular.module('arethusa.morph').service('morph', [
 
     this.loadInitalAnalyses = function () {
       var analyses = self.seedAnalyses(state.tokens);
-      if (! self.noRetrieval) {
+      if (self.noRetrieval !== "all") {
         angular.forEach(analyses, function (val, id) {
-          self.getExternalAnalyses(val);
+          if (self.noRetrieval !== "online") {
+            self.getExternalAnalyses(val);
+          }
           self.getAnalysisFromState(val, id);
           val.analyzed = true;
         });

--- a/app/static/configs/local.json
+++ b/app/static/configs/local.json
@@ -88,7 +88,7 @@
         }
       },
       "matchAll" : true,
-      "noRetrieval" : true,
+      "noRetrieval" : "online",
       "fileUrl" : "./static/configs/morph/attributes.json"
     },
 


### PR DESCRIPTION
The noRetrieval option now takes a string. This string can be all "all"
to stop all retrieval (even from the state object itself) or "online"
to stop querying external services, but still retrieve morphological
forms from the state ojects, i.e. the loaded document(s).
