### PR TITLE
Set notifier duration to 0 for e2e specs

### DIFF
--- a/app/static/configs/e2e.json
+++ b/app/static/configs/e2e.json
@@ -22,6 +22,10 @@
     "navigation" : true
   },
 
+  "notifier" : {
+    "duration" : "0"
+  },
+
   "resources" : {
     "e2e" : {
       "route" : "http://services.perseids.org/llt-data/:doc.:s.xml",


### PR DESCRIPTION
Default time for notifier messages to stay up is 5 seconds (cf. #167) - this is done with a `$timeout` value. The e2e specs don't like this, as protractor waits for this timeout to run ot before it moves to the next spec. Therefore we set the duration for e2e specs to 0, as we don't want to drag our performance down to unacceptable levels.

Also avoids timeout problems with travis and saucelabs. 
