### PR TITLE
Morph preselection handling

### DIFF
--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -143,7 +143,7 @@ angular.module('arethusa.morph').service('morph', [
       });
     };
 
-    this.getExternalAnalyses = function (analysisObj) {
+    this.getExternalAnalyses = function (analysisObj, id) {
       angular.forEach(morphRetrievers, function (retriever, name) {
         retriever.getData(analysisObj.string, function (res) {
           res.forEach(function (el) {
@@ -155,18 +155,26 @@ angular.module('arethusa.morph').service('morph', [
             getDataFromInventory(el);
           });
           arethusaUtil.pushAll(analysisObj.forms, res);
+          preselectForm(analysisObj.forms[0], id);
         });
       });
     };
+
+    function preselectForm(form, id) {
+      var currentSel = state.getToken(id).morphology;
+      if (form && currentSel !== form) {
+        self.setState(id, form);
+      }
+    }
 
     function loadInitalAnalyses() {
       var analyses = self.seedAnalyses(state.tokens);
       if (self.noRetrieval !== "all") {
         angular.forEach(analyses, function (val, id) {
-          if (self.noRetrieval !== "online") {
-            self.getExternalAnalyses(val);
-          }
           self.getAnalysisFromState(val, id);
+          if (self.noRetrieval !== "online") {
+            self.getExternalAnalyses(val, id);
+          }
           val.analyzed = true;
           self.resetCustomForm(val);
         });


### PR DESCRIPTION
Fixes bug when reading in treebank documents where the postag is an empty string (which can be ignored).

In such cases we also want to do an automated preselection of an externally retrieved form if we have one.
