### PR TITLE
Destroy childScopes in dependencyTree

### DIFF
--- a/app/js/arethusa.dep_tree/directives/dependency_tree.js
+++ b/app/js/arethusa.dep_tree/directives/dependency_tree.js
@@ -586,7 +586,9 @@ angular.module('arethusa.depTree').directive('dependencyTree', [
           applyViewMode();
         });
 
+        var headWatches = [];
         function createHeadWatches() {
+          destroyOldHeadWatches();
           angular.forEach(scope.tokens, function (token, id) {
             var childScope = scope.$new();
             childScope.token = token.id;
@@ -605,7 +607,15 @@ angular.module('arethusa.depTree').directive('dependencyTree', [
                 render();
               }
             });
+            headWatches.push(childScope);
           });
+        }
+
+        function destroyOldHeadWatches() {
+          angular.forEach(headWatches, function(childScope, i) {
+            childScope.$destroy();
+          });
+          headWatches = [];
         }
 
 


### PR DESCRIPTION
This is just a single commit, but deserves an own PR because it's important. The problem has already been mentioned in #121 and #211.

We NEED to destroy the childScopes we are creating in `dependencyTree`. These are used to watch head changes. Angular has no chance to clean them up on its own, because the scope of the `dependencyTree` plugin is never deregistered when we move between `state` states. This is generally a good thing, as we do not have to reload everything again and can just re-use the DOM elements we already rendered on the page.

But if we are going to introduce lots of new scopes manually there, it is our responsible to clean them up in case they are not needed anymore.

This is very interesting and needs to be investigated even more. #121 already mentions that we demand a lot of JS's garbage collector as we don't release objects when we move from state to state. Could be that this leads elsewhere to problems as well, I am not sure.

This PR at least fixes these problems within the `dependencyDirective` for the most part. It's using the same logic as `unusedTokenHighlighter`. We should extract this at some point and DRY our code up. 
