### PR TITLE
Allow to set globalDefaults via route param

### DIFF
--- a/app/js/arethusa.core/configurator.js
+++ b/app/js/arethusa.core/configurator.js
@@ -28,8 +28,9 @@ angular.module('arethusa.core').service('configurator', [
   'Resource',
   'Auth',
   '$timeout',
+  '$location',
   'Loader',
-  function ($injector, $http, $rootScope, Resource, Auth, $timeout, Loader) {
+  function ($injector, $http, $rootScope, Resource, Auth, $timeout, $location, Loader) {
     var self = this;
     var includeParam = 'fileUrl';
 
@@ -252,13 +253,22 @@ angular.module('arethusa.core').service('configurator', [
 
     function setGlobalDefaults(obj) {
       var customDefaults = self.configuration.main.globalDefaults || {};
-      var defaults = angular.extend(globalDefaults, customDefaults);
+      var routeDefaults  = getGlobalDefaultsFromRoute();
+      var defaults = angular.extend(globalDefaults, customDefaults, routeDefaults);
       angular.forEach(defaults, function(value, key) {
         // Explicitly ask for undefined, as a false value can be a
         // valid configuration seting!
         if (obj[key] === undefined) {
           obj[key] = value;
         }
+      });
+    }
+
+    var routeParams = ['mode'];
+    function getGlobalDefaultsFromRoute() {
+      return arethusaUtil.inject({}, routeParams, function(memo, param) {
+        var value = $location.search()[param];
+        if (value) memo[param] = value;
       });
     }
 


### PR DESCRIPTION
Configurator can now listen to route params to define/override global defaults.

This is only activated for the read only mode by adding `mode=viewer` to a route.

The Read Only mode (#193) doesn't perform too well for now in general. (check also #245). All issues are pretty minor, but need to look at them one by one.
