### PR TITLE
Extend morph form of document, not duplicate it

### DIFF
--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -161,11 +161,34 @@ angular.module('arethusa.morph').service('morph', [
             // try to obtain additional info from the inventory
             getDataFromInventory(el);
           });
+          mergeDuplicateForms(analysisObj.forms[0], res);
           arethusaUtil.pushAll(analysisObj.forms, res);
           preselectForm(analysisObj.forms[0], id);
         });
       });
     };
+
+    function mergeDuplicateForms(firstForm, otherForms) {
+      if (firstForm && firstForm.origin === 'document') {
+        var duplicate;
+        for (var i = otherForms.length - 1; i >= 0; i--){
+          var el = otherForms[i];
+          if (isSameForm(firstForm, el)) {
+            duplicate = el;
+            break;
+          }
+        }
+        if (duplicate) {
+          angular.extend(firstForm, duplicate);
+          firstForm.origin = 'document';
+          otherForms.splice(otherForms.indexOf(duplicate), 1);
+        }
+      }
+    }
+
+    function isSameForm(a, b) {
+      return a.lemma === b.lemma && a.postag === b.postag;
+    }
 
     function preselectForm(form, id) {
       var currentSel = state.getToken(id).morphology;


### PR DESCRIPTION
When a form is already contained in a document, a call to the morphology service will most likely find the same analysis again.

When this is the case, we merge the additional info the external analysis provides (such as Lexical Inventory data) with the document's original form.

Right now we compare by lemma and postag, at a later stage we can leverage the Lexical Inventory here and compare just by URI, which will be more efficient and less error prone (there might be rare edge cases where our current approach won't return nice results).

Not sure if and how a user should be notified of such a process. I guess most people won't care - and they won't be confused by the appearance of a duplicate fomr.
