### PR TITLE
Add min and max width to sidepanel

### DIFF
--- a/app/js/arethusa.core/directives/resizable.js
+++ b/app/js/arethusa.core/directives/resizable.js
@@ -6,10 +6,12 @@ angular.module('arethusa.core').directive('resizable', [
     return {
       restrict: 'AEC',
       link: function (scope, element, attrs) {
-        var maxSize = $window.innerWidth;
-        var maxPos = maxSize - 400;
         var main = angular.element(document.getElementById('main-body'));
         var win = angular.element($window);
+        var panel = element.parent();
+
+        var panelMin = 260;
+        var mainMin  = 260;
 
         element.on('mousedown', function (event) {
           event.preventDefault();
@@ -28,14 +30,21 @@ angular.module('arethusa.core').directive('resizable', [
         // by step.
         function mousemove(event) {
           var x = Math.floor(event.pageX);
-          var el = element.parent();
-          var leftPos = Math.round(el.position().left);
-          var width = Math.round(el.width());
+          var leftPos = Math.round(panel.position().left);
+          var width = Math.round(panel.width());
           var border = leftPos + width;
           var diff = x - leftPos;
-          var newSize = width - diff;
-          el.width(newSize);
-          main.width(main.width() + diff);
+          var panelSize = width - diff;
+          var mainSize  = main.width() + diff;
+
+          if (withinBoundaries(panelSize, mainSize)) {
+            panel.width(panelSize);
+            main.width(mainSize);
+          }
+        }
+
+        function withinBoundaries(panel, main) {
+          return panel > panelMin && main > mainMin;
         }
 
         function mouseup() {


### PR DESCRIPTION
In addition to #262 

Irresponsible resizing is now prevented. The main body as well as the sidepanel need to have a minimal width, otherwise some visual issues can arise - and the user doesn't have any benefit of a ten pixel wide main body anyway.

The optimal min width setting is debatable though, but looks quite OK at 260px. Might be challenging for a mobile layout though, but that's another story anyway.
