### PR TITLE
Giuseppe's SG fixes

### DIFF
--- a/app/static/configs/sg.json
+++ b/app/static/configs/sg.json
@@ -111,7 +111,7 @@
       "template" : "templates/sg.html",
       "contextMenu" : true,
       "contextMenuTemplate": "templates/arethusa.sg/context_menu.html",
-      "fileUrl" : "./static/configs/sg/sg_labels.json"
+      "fileUrl" : "./static/configs/sg2/sg_labels.json"
     },
 
     "relation" : {

--- a/app/static/configs/sg2/sg_labels.json
+++ b/app/static/configs/sg2/sg_labels.json
@@ -1,0 +1,69 @@
+{
+  "labels" : {
+    "ADJ" : {
+      "short" : "ADJ",
+      "long" : "adjective",
+      "sections" : "1018-1093",
+      "dependency" : {
+        "pos" : "adj"
+      },
+      "fileUrl" : "./static/configs/sg2/sg_labels/adjectives.json"
+    },
+    "ART" : {
+      "short" : "ART",
+      "long" : "article",
+      "sections" : "1099-1189",
+      "dependency" : {
+        "pos" : "art"
+      }
+    },
+    "PRN" : {
+      "short" : "PRN",
+      "long" : "pronoun",
+      "sections" : "1190-1278",
+      "dependency" : {
+        "pos" : "pron"
+      },
+      "fileUrl" : "./static/configs/sg2/sg_labels/pronouns.json"
+    },
+    "ADP" : {
+      "short" : "ADP",
+      "long" : "adposition",
+      "sections" : "1636-1702",
+      "dependency" : {
+        "pos" : "prep"
+      }
+    },
+    "NOUN" : {
+      "short" : "NOUN",
+      "long" : "noun",
+      "sections" : "1279-1635",
+      "dependency" : {
+        "pos" : "noun"
+      },
+      "fileUrl" : "./static/configs/sg2/sg_labels/cases.json"
+    },
+    "VERB" : {
+      "short" : "VERB",
+      "long" : "verb",
+      "dependency" : {
+        "pos" : "verb"
+      },
+      "fileUrl" : "./static/configs/sg2/sg_labels/verbs.json"
+    },
+    "ADV" : {
+      "short" : "ADV",
+      "long" : "adverb",
+      "sections" : "1094-1098",
+      "dependency" : {
+        "pos" : "adv"
+      },
+      "fileUrl" : "./static/configs/sg2/sg_labels/adverbs.json"
+    },
+    "CLS" : {
+      "short" : "CLS",
+      "long" : "clause",
+      "fileUrl" : "./static/configs/sg2/sg_labels/clauses.json"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/accusative_cases.json
+++ b/app/static/configs/sg2/sg_labels/accusative_cases.json
@@ -1,0 +1,132 @@
+{
+  "nested" : {
+    "DPN" : {
+      "short" : "DPN",
+      "long" : "dependent",
+      "nested" : {
+        "EFF" : {
+          "short" : "EFF",
+          "long" : "internal object",
+          "sections" : "1563-1577",
+          "nested" : {
+            "CGN" : {
+              "short" : "CGN",
+              "long" : "of result/cognate",
+              "sections" : "1563-1579"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "AFF" : {
+          "short" : "AFF",
+          "long" : "external object",
+          "sections" : "1590-1598"
+        },
+        "EXT" : {
+          "short" : "EXT",
+          "long" : "extent",
+          "sections" : "1580-1587",
+          "nested" : {
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "time",
+              "sections" : "1582-1587"
+            },
+            "SPC" : {
+              "short" : "SPC",
+              "long" : "space",
+              "sections" : "1581"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "TRM" : {
+          "short" : "TRM",
+          "long" : "terminal of space",
+          "sections" : "1588-1589"
+        },
+        "RSP" : {
+          "short" : "RSP",
+          "long" : "of respect",
+          "sections" : "1600-1605"
+        },
+        "ADP" : {
+          "short" : "ADP",
+          "long" : "prepositional",
+          "nested" : {
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "terminal of time (with ἀνά, εἰς, μετά, κατά, παρά, πρός, ὑπό, ὑπέρ)"
+            },
+            "MNN" : {
+              "short" : "MNN",
+              "long" : "manner (with ἀνά, εἰς, κατά)"
+            },
+            "CAU" : {
+              "short" : "CAU",
+              "long" : "cause (with διά, παρά)"
+            },
+            "PUR" : {
+              "short" : "PUR",
+              "long" : "purpose (with διά, εἰς, ἐπί, κατά, πρός)"
+            },
+            "MEA" : {
+              "short" : "MEA",
+              "long" : "measure (with εἰς, ἐπί, παρά, ὑπέρ)"
+            },
+            "STN" : {
+              "short" : "STN",
+              "long" : "of standard of judgement (with πρός)"
+            }
+          }
+        },
+        "UNS" : {
+          "short" : "UNS",
+          "long" : "unspecified (only if depending on adj., adv. or adp.)"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "IND" : {
+      "short" : "IND",
+      "long" : "independent",
+      "sections" : "1599",
+      "nested" : {
+        "ELL" : {
+          "short" : "ELL",
+          "long" : "elliptical accusative",
+          "sections" : "1599"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adj_cl.json
+++ b/app/static/configs/sg2/sg_labels/adj_cl.json
@@ -1,0 +1,22 @@
+{
+  "nested" : {
+    "ADJ_CL_PRP" : {
+      "short" : "ADJ_CL_PRP",
+      "long" : "adjective clause proper",
+      "fileUrl" : "./static/configs/sg/sg_labels/adj_cl_prp.json"
+    },
+    "SBS_ADJ_CL" : {
+      "short" : "SBS_ADJ_CL",
+      "long" : "substantivized adjective clause",
+      "fileUrl" : "./static/configs/sg/sg_labels/sbs_adj_cl.json"
+    },
+    "ADJ_CL_NAB" : {
+      "short" : "ADJ_CL_NAB",
+      "long" : "none of the above"
+    },
+    "ADJ_CL_IDK" : {
+      "short" : "ADJ_CL_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adj_cl_prp.json
+++ b/app/static/configs/sg2/sg_labels/adj_cl_prp.json
@@ -1,0 +1,42 @@
+{
+  "nested" : {
+    "ORD" : {
+      "short" : "ORD",
+      "long" : "ordinary relative clause",
+      "sections" : "2553",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "FNL" : {
+      "short" : "FNL",
+      "long" : "final relative clause",
+      "sections" : "2554",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CAU" : {
+      "short" : "CAU",
+      "long" : "cause relative clause",
+      "sections" : "2555",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CNS" : {
+      "short" : "CNS",
+      "long" : "consecutive relative clause",
+      "sections" : "2556-2559",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CND" : {
+      "short" : "CND",
+      "long" : "conditional relative clause",
+      "sections" : "2560-2573",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adj_prt.json
+++ b/app/static/configs/sg2/sg_labels/adj_prt.json
@@ -1,0 +1,100 @@
+{
+  "nested" : {
+    "ATR_PRT" : {
+      "short" : "ATR_PRT",
+      "long" : "attributive",
+      "sections" : "2049-2053"
+    },
+    "CRC_PRT" : {
+      "short" : "CRC_PRT",
+      "long" : "circumstantial",
+      "sections" : "2054-2087",
+      "nested" : {
+        "TMP_PRT" : {
+          "short" : "TMP_PRT",
+          "long" : "time",
+          "sections" : "2061"
+        },
+        "MNN_PRT" : {
+          "short" : "MNN_PRT",
+          "long" : "manner",
+          "sections" : "2062"
+        },
+        "MNS_PRT" : {
+          "short" : "MNS_PRT",
+          "long" : "means",
+          "sections" : "2063"
+        },
+        "CAU_PRT" : {
+          "short" : "CAU_PRT",
+          "long" : "cause",
+          "sections" : "2064"
+        },
+        "PRP_PRT" : {
+          "short" : "PRP_PRT",
+          "long" : "purpose",
+          "sections" : "2065"
+        },
+        "CNC_PRT" : {
+          "short" : "CNC_PRT",
+          "long" : "concession",
+          "sections" : "2066"
+        },
+        "CND_PRT" : {
+          "short" : "CND_PRT",
+          "long" : "condition",
+          "sections" : "2067"
+        },
+        "ATD_PRT" : {
+          "short" : "ATD_PRT",
+          "long" : "of any attendant circumstance",
+          "sections" : "2068"
+        },
+        "CRC_NAB" : {
+          "short" : "CRC_NAB",
+          "long" : "none of the above"
+        },
+        "CRC_IDK" : {
+          "short" : "CRC_IDK",
+          "long" : "I do not know"
+        }
+      }
+    },
+    "SPL_PRT" : {
+      "short" : "SPL_PRT",
+      "long" : "supplementary",
+      "sections" : "2088-2148",
+      "nested" : {
+        "IND_PRT" : {
+          "short" : "IND_PRT",
+          "long" : "in indirect discourse"
+        },
+        "NIN_PRT" : {
+          "short" : "NIN_PRT",
+          "long" : "not in indirect discourse"
+        },
+        "SPL_NAB" : {
+          "short" : "SPL_NAB",
+          "long" : "none of the above"
+        },
+        "SPL_IDK" : {
+          "short" : "SPL_IDK",
+          "long" : "I do not know"
+        }
+      }
+    },
+    "PRH_PRT" : {
+      "short" : "PRH_PRT",
+      "long" : "periphrastic",
+      "sections" : "2091"
+    },
+    "ADJ_PRT_NAB" : {
+      "short" : "ADJ_PRT_NAB",
+      "long" : "none of the above"
+    },
+    "ADJ_PRT_IDK" : {
+      "short" : "ADJ_PRT_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adjectives.json
+++ b/app/static/configs/sg2/sg_labels/adjectives.json
@@ -1,0 +1,31 @@
+{
+  "nested" : {
+    "ADJ_PRP" : {
+      "short" : "ADJ_PRP",
+      "long" : "proper"
+    },   
+    "SBS_ADJ" : {
+      "short" : "SBS_ADJ",
+      "long" : "substantive",
+      "sections" : "1021-1029",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "VRB_ADJ" : {
+      "short" : "VRB_ADJ",
+      "long" : "vbl adj in τος/τεος"
+    },
+    "SVR_ADJ" : {
+      "short" : "SVR_ADJ",
+      "long" : "sub. vbl adjective in τος/τεος",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "ADJ_NAB" : {
+      "short" : "ADJ_NAB",
+      "long" : "none of the above"
+    },
+    "ADJ_IDK" : {
+      "short" : "ADJ_IDK",
+      "long" : "I do not know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adv_cl.json
+++ b/app/static/configs/sg2/sg_labels/adv_cl.json
@@ -1,0 +1,54 @@
+{
+  "nested" : {
+    "PRP" : {
+      "short" : "PRP",
+      "long" : "purpose clause",
+      "sections" : "2193-2206",
+      "fileUrl" : "./static/configs/sg/sg_labels/drc_ind.json"
+    },
+    "CAU" : {
+      "short" : "CAU",
+      "long" : "causal clause",
+      "sections" : "2240-2248",
+      "fileUrl" : "./static/configs/sg/sg_labels/drc_ind.json"
+    },
+    "RSL" : {
+      "short" : "RSL",
+      "long" : "result clause",
+      "sections" : "2249-2278",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CND" : {
+      "short" : "CND",
+      "long" : "conditional clause",
+      "sections" : "2280-2368",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CNC" : {
+      "short" : "CNC",
+      "long" : "concessive clause",
+      "sections" : "2369-2382",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "TMP" : {
+      "short" : "TMP",
+      "long" : "temporal clause",
+      "sections" : "2383-2461",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "CMP" : {
+      "short" : "CMP",
+      "long" : "clause of comparison",
+      "sections" : "2462-2487",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/adverbs.json
+++ b/app/static/configs/sg2/sg_labels/adverbs.json
@@ -1,0 +1,84 @@
+{
+  "nested" : {
+    "ADV_TMP_LCT" : {
+      "short" : "ADV_TMP_LCT",
+      "long" : "time (with force of genitive/dative)"
+    },
+    "ADV_TMP_ABL" : {
+      "short" : "ADV_TMP_ABL",
+      "long" : "time (with the force of genitive of separation)"
+    },
+    "ADV_TMP_EXT" : {
+      "short" : "ADV_TMP_EXT",
+      "long" : "of time (with force of accusative of extent)"
+    },
+    "ADV_TMP_ADL" : {
+      "short" : "ADV_TMP_ADL",
+      "long" : "of time (with force of terminal accusative)"
+    },
+    "ADV_PLC_LCT" : {
+      "short" : "ADV_PLC_LCT",
+      "long" : "place (with force of genitive/dative)"
+    },
+    "ADV_PLC_ABL" : {
+      "short" : "ADV_PLC_ABL",
+      "long" : "place (with the force of genitive of separation)"
+    },
+    "ADV_PLC_EXT" : {
+      "short" : "ADV_PLC_EXT",
+      "long" : "place (with force of accusative of extent)"
+    },
+    "ADV_PLC_ADL" : {
+      "short" : "ADV_PLC_ADL",
+      "long" : "place (with force of terminal accusative)"
+    },
+    "ADV_SRC" : {
+      "short" : "ADV_SRC",
+      "long" : "source"
+    },
+    "ADV_CAU" : {
+      "short" : "ADV_CAU",
+      "long" : "cause"
+    },
+    "ADV_RSL" : {
+      "short" : "ADV_RSL",
+      "long" : "result"
+    },
+    "ADV_MNN" : {
+      "short" : "ADV_MNN",
+      "long" : "manner"
+    },
+    "ADV_MSR" : {
+      "short" : "ADV_MSR",
+      "long" : "measure"
+    },
+    "ADV_INS" : {
+      "short" : "ADV_INS",
+      "long" : "instrument/means"
+    },
+    "ADV_PRP" : {
+      "short" : "ADV_PRP",
+      "long" : "purpose"
+    },
+    "ADV_CNC" : {
+      "short" : "ADV_CNC",
+      "long" : "concession"
+    },
+    "ADV_NGT" : {
+      "short" : "ADV_NGT",
+      "long" : "negation"
+    },
+    "ADV_UNS" : {
+      "short" : "ADV_UNS",
+      "long" : "unspecified"
+    },
+    "ADV_NAB" : {
+      "short" : "ADV_NAB",
+      "long" : "none of the above"
+    },
+    "ADV_IDK" : {
+      "short" : "ADV_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/cases.json
+++ b/app/static/configs/sg2/sg_labels/cases.json
@@ -1,0 +1,48 @@
+{
+  "nested" : {
+    "NMN" : {
+      "short" : "NMN",
+      "long" : "nominative",
+      "sections" : "938-943",
+      "dependency" : {
+        "case" : "nom"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/nominative_cases.json"
+    },
+    "GNT" : {
+      "short" : "GNT",
+      "long" : "genitive",
+      "sections" : "1289-1449",
+      "dependency" : {
+        "case" : "gen"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/genetive_cases.json"
+    },
+    "DTV" : {
+      "short" : "DTV",
+      "long" : "dative",
+      "sections" : "1450-1550",
+      "dependency" : {
+        "case" : "dat"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/dative_cases.json"
+    },
+    "ACC" : {
+      "short" : "ACC",
+      "long" : "accusative",
+      "sections" : "1551-1635",
+      "dependency" : {
+        "case" : "acc"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/accusative_cases.json"
+    },
+    "VOC" : {
+      "short" : "VOC",
+      "long" : "vocative",
+      "sections" : "1283-1288",
+      "dependency" : {
+        "case" : "voc"
+      }
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/clauses.json
+++ b/app/static/configs/sg2/sg_labels/clauses.json
@@ -1,0 +1,116 @@
+{
+  "nested" : {
+    "SBS" : {
+      "short" : "SBS",
+      "long" : "substantive",
+      "sections" : "2574-2588",
+      "nested" : {
+        "STM" : {
+          "short" : "STM",
+          "long" : "statement",
+          "sections" : "2575"
+        },
+        "WDS" : {
+          "short" : "WDS",
+          "long" : "will or desire",
+          "sections" : "2575"
+        },
+        "QST" : {
+          "short" : "QST",
+          "long" : "question",
+          "sections" : "2575"
+        },
+        "EXC" : {
+          "short" : "EXC",
+          "long" : "exclamation",
+          "sections" : "2575"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "ADJ" : {
+      "short" : "ADJ",
+      "long" : "adjective",
+      "sections" : "2488-2573",
+      "nested" : {
+        "PUR" : {
+          "short" : "PUR",
+          "long" : "as relative clause of purpose",
+          "sections" : "2554"
+        },
+        "CAU" : {
+          "short" : "CAU",
+          "long" : "as relative clause of cause",
+          "sections" : "2555"
+        },
+        "RSL" : {
+          "short" : "RSL",
+          "long" : "as relative clause of result",
+          "sections" : "2556-2559"
+        },
+        "CND" : {
+          "short" : "CND",
+          "long" : "as relative clause of condition",
+          "sections" : "2560-2573"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "ADV" : {
+      "short" : "ADV",
+      "sections" : "2191-2487",
+      "long" : "adverd",
+      "nested" : {
+        "PUR" : {
+          "short" : "PUR",
+          "long" : "of purpose",
+          "sections" : "2193-2206"
+        },
+        "CAU" : {
+          "short" : "CAU",
+          "long" : "of cause",
+          "sections" : "2240-2248"
+        },
+        "RSL" : {
+          "short" : "RSL",
+          "long" : "of result",
+          "sections" : "2249-2279"
+        },
+        "CND" : {
+          "short" : "CND",
+          "long" : "of condition",
+          "sections" : "2279-2368"
+        },
+        "CNC" : {
+          "short" : "CNC",
+          "long" : "of concession",
+          "sections" : "2369-2382"
+        },
+        "TMP" : {
+          "short" : "TMP",
+          "long" : "of time",
+          "sections" : "2383-2461"
+        },
+        "CMP" : {
+          "short" : "CMP",
+          "long" : "of comparison",
+          "sections" : "2462"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I don't know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/dative_cases.json
+++ b/app/static/configs/sg2/sg_labels/dative_cases.json
@@ -1,0 +1,234 @@
+{
+  "nested" : {
+    "PRP" : {
+      "short" : "PRP",
+      "long" : "proper",
+      "sections" : "1457-1502",
+      "nested" : {
+        "DRC" : {
+          "short" : "DRC",
+          "long" : "direct complement of verbs",
+          "sections" : "1460-1468"
+        },
+        "INR" : {
+          "short" : "INR",
+          "long" : "indirect complement of verbs",
+          "sections" : "1469-1470"
+        },
+        "INT" : {
+          "short" : "INT",
+          "long" : "interest",
+          "sections" : "1474-1494",
+          "nested" : {
+            "POS" : {
+              "short" : "POS",
+              "long" : "possessor",
+              "sections" : "1476-1480"
+            },
+            "ADG" : {
+              "short" : "ADG",
+              "long" : "advantage and disadvantage",
+              "sections" : "1481-1485"
+            },
+            "FLN" : {
+              "short" : "FLN",
+              "long" : "feeling",
+              "sections" : "1486"
+            },
+            "INC" : {
+              "short" : "INC",
+              "long" : "with participle of inclination or aversion",
+              "sections" : "1487"
+            },
+            "AGN" : {
+              "short" : "AGN",
+              "long" : "agent",
+              "sections" : "1488-1494"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "RLT" : {
+          "short" : "RLT",
+          "long" : "relation",
+          "sections" : "1495-1498",
+          "nested" : {
+            "RFR" : {
+              "short" : "RFR",
+              "long" : "reference",
+              "sections" : "1496-1497"
+            },
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "with a participle of expressing time",
+              "sections" : "1498"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "INS" : {
+      "short" : "INS",
+      "long" : "instrumental",
+      "sections" : "1503-1529",
+      "nested" : {	          
+        "INS_PRP" : {
+          "short" : "INT_PRP",
+          "long" : "instrumental proper",
+          "sections" : "1506-1520",
+          "nested" : {
+            "MNS" : {
+              "short" : "MNS",
+              "long" : "means or instruments",
+              "sections" : "1507-1511"
+            },
+            "STN" : {
+              "short" : "STN",
+              "long" : "standard of judgement",
+              "sections" : "1512"
+            },
+            "MNN" : {
+               "short" : "MNN",
+               "long" : "manner",
+               "sections" : "1527"
+            },
+            "MEA" : {
+               "short" : "MEA",
+               "long" : "measure of difference",
+               "sections" : "1513-1515"
+            },
+            "RSP" : {
+               "short" : "RSP",
+               "long" : "respect",
+               "sections" : "1516"
+            },
+            "CAU" : {
+               "short" : "CAU",
+               "long" : "cause",
+               "sections" : "1520"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "CMT" : {
+          "short" : "CMT",
+          "long" : "comitative",
+          "sections" : "1521-1528",
+          "nested" : {
+            "ASS" : {
+              "short" : "ASS",
+              "long" : "association",
+              "sections" : "1523"
+            },
+            "ACM" : {
+              "short" : "ACM",
+              "long" : "accompaniment",
+              "sections" : "1524-1525"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        }
+      },
+      "NAB" : {
+        "short" : "NAB",
+        "long" : "none of the above"
+      },
+      "IDK" : {
+        "short" : "IDK",
+        "long" : "I don't know"
+      }
+    },
+    "LCT" : {
+      "short" : "LCT",
+      "long" : "locative",
+      "sections" : "1530-1550",
+      "nested" : {
+        "TME" : {
+          "short" : "TME",
+          "long" : "of time",
+          "sections" : "1539-1543"
+        },
+        "PLC" : {
+          "short" : "PLC",
+          "long" : "of place",
+          "sections" : "1531-1538"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "PRP" : {
+      "short" : "PRP",
+      "long" : "prepositional",
+      "nested" : {
+        "PUR" : {
+        "short" : "PUR",
+        "long" : "purpose (with ἐπί)"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }    
+      }
+    },
+    "UNS" : {
+      "short" : "UNS",
+      "long" : "unspecified (only if depending on adj., adv., or adp.)"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I don't know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/finite_verbs.json
+++ b/app/static/configs/sg2/sg_labels/finite_verbs.json
@@ -1,0 +1,60 @@
+{
+  "nested" : {
+    "FNT_MOO_DPN" : {
+      "short" : "FNT_MOO_DPN",
+      "long" : "dependent",
+      "fileUrl" : "./static/configs/sg/sg_labels/fnt_moo_vrb_dpn_cls.json"
+    },
+    "FNT_MOO_IND" : {
+      "short" : "FNT_MOO_IND",
+      "long" : "independent",
+      "nested" : {
+        "FNT_MOO_STM" : {
+          "short" : "FNT_MOO_STM",
+          "long" : "statement",
+          "sections" : "2153"
+        },
+        "FNT_MOO_ASS" : {
+          "short" : "FNT_MOO_ASS",
+          "long" : "assumption",
+          "sections" : "2154"
+        },
+        "FNT_MOO_COM" : {
+          "short" : "FNT_MOO_COM",
+          "long" : "command",
+          "sections" : "2155"
+        },
+        "FNT_MOO_WSH" : {
+          "short" : "FNT_MOO_WSH",
+          "long" : "wish",
+          "sections" : "2156"
+        },
+        "FNT_MOO_QST" : {
+          "short" : "FNT_MOO_QST",
+          "long" : "question",
+          "sections" : "2157"
+        },
+        "FNT_MOO_EXC" : {
+          "short" : "FNT_MOO_EXC",
+          "long" : "exclamation",
+          "sections" : "2158"
+        },
+        "FNT_MOO_NAB" : {
+          "short" : "FNT_MOO_NAB",
+          "long" : "none of the above"
+        },
+        "FNT_MOO_IDK" : {
+          "short" : "FNT_MOO_IDK",
+          "long" : "I don't know"
+        }
+      },
+    "FNT_MOO_NAB" : {
+      "short" : "FNT_MOO_NAB",
+      "long" : "none of the above"
+    },
+    "FNT_MOO_IDK" : {
+      "short" : "FNT_MOO_IDK",
+      "long" : "I do not know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/fnt_moo_vrb_dpn_cls.json
+++ b/app/static/configs/sg2/sg_labels/fnt_moo_vrb_dpn_cls.json
@@ -1,0 +1,27 @@
+{
+  "nested" : {
+    "SBS_CLS" : {
+      "short" : "SBS_CLS",
+      "long" : "substantive clause",
+      "fileUrl" : "./static/configs/sg/sg_labels/sbs_cl.json"
+    },
+    "ADJ_CLS" : {
+      "short" : "ADJ_CLS",
+      "long" : "adjective clause",
+      "fileUrl" : "./static/configs/sg/sg_labels/adj_cl.json"
+    },
+    "ADV_CLS" : {
+      "short" : "ADV_CLS",
+      "long" : "adverb clause",
+      "fileUrl" : "./static/configs/sg/sg_labels/adv_cl.json"
+    },
+    "CLS_NAB" : {
+      "short" : "CLS_NAB",
+      "long" : "none of the above"
+    },
+    "CLS_IDK" : {
+      "short" : "CLS_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/genetive_cases.json
+++ b/app/static/configs/sg2/sg_labels/genetive_cases.json
@@ -1,0 +1,251 @@
+{
+  "nested" : {
+    "DPN" : {
+      "short" : "DPN",
+      "long" : "dependent",
+      "sections" : "1289-1449",
+      "nested" : {
+        "PRP" : {
+          "short" : "PRP",
+          "long" : "proper",
+          "sections" : "1290-1390",
+          "nested" : {
+            "POS" : {
+              "short" : "POS",
+              "long" : "possession or belonging",
+              "sections" : "1297-1305"
+            },
+            "DVD" : {
+              "short" : "DVD",
+              "long" : "divided whole",
+              "sections" : "1306-1319;1341-1371"
+            },
+            "QLT" : {
+              "short" : "QLT",
+              "long" : "quality",
+              "sections" : "1320-1321"
+            },
+            "EXP" : {
+              "short" : "EXP",
+              "long" : "explanation",
+              "sections" : "1322"
+            },
+            "MTR" : {
+              "short" : "MTR",
+              "long" : "material or contents",
+              "sections" : "1323-1324"
+            },
+            "MSR" : {
+              "short" : "MSR",
+              "long" : "measure",
+              "sections" : "1325-1327"
+            },
+            "SBJ-OBJ" : {
+              "short" : "SBJ-OBJ",
+              "long" : "subj. or obj.",
+              "sections" : "1328-1335",
+              "nested" : {
+                "SBJ" : {
+                  "short" : "SBJ",
+                  "long" : "subjective",
+                  "sections" : "1330"
+                },
+                "OBJ" : {
+                  "short" : "OBJ",
+                  "long" : "objective",
+                  "sections" : "1331-1335"
+                },
+                "NAB" : {
+                  "short" : "NAB",
+                  "long" : "none of the above"
+                },
+                "IDK" : {
+                  "short" : "IDK",
+                  "long" : "I don't know"
+                }
+              }
+            },
+            "PRC" : {
+              "short" : "PRC",
+              "long" : "price and value",
+              "sections" : "1336;1372-1374"
+            },
+            "CRM" : {
+              "short" : "CRM",
+              "long" : "crime and accountability",
+              "sections" : "1375-1379"
+            },
+            "CNN" : {
+              "short" : "CNN",
+              "long" : "topic",
+              "sections" : "1380-1381"
+            },
+            "NAB" : {
+            "short" : "NAB",
+            "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "ABL" : {
+          "short" : "ABL",
+          "long" : "ablatival",
+          "sections" : "1391-1411",
+          "nested" : {
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "temporal starting point"
+            },
+            "SPR" : {
+              "short" : "SPR",
+              "long" : "separation",
+              "sections" : "1392-1400"
+            },
+            "DST" : {
+              "short" : "DST",
+              "long" : "distinction and comparison",
+              "sections" : "1401-1404"
+            },
+            "CAU" : {
+              "short" : "CAU",
+              "long" : "cause",
+              "sections" : "1405-1409"
+            },
+            "PUR" : {
+              "short" : "PUR",
+              "long" : "purpose",
+              "sections" : "1408"
+            },
+            "SRC" : {
+              "short" : "SRC",
+              "long" : "source",
+              "sections" : "1410-1411"
+            },
+            "NAB" : {
+            "short" : "NAB",
+            "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "TI-SP" : {
+          "short" : "TI-SP",
+          "long" : "time and place",
+          "sections" : "1444-1449",
+          "nested" : {
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "time",
+              "sections" : "1444-1447"
+            },
+            "SPC" : {
+              "short" : "SPC",
+              "long" : "place",
+              "sections" : "1448-1449"
+            },
+            "NAB" : {
+             "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "W-PREP" : {
+          "short" : "W-PREP",
+          "long" : "prepositional",
+          "nested" : {
+            "TMP" : {
+              "short" : "TMP",
+              "long" : "time extension (with διά, μέχρι)"
+            },
+            "SPC" : {
+              "short" : "SPC",
+              "long" : "space extension (with διά, μέχρι)"
+            },
+            "CAU" : {
+              "short" : "CAU",
+              "long" : "cause (with ἀπό, ἐξ, ὑπό)"
+            },
+            "MNS" : {
+              "short" : "MNS",
+              "long" : "means or instrument (with ἀπό, διά, ἐξ)"
+            },
+            "AGT" : {
+              "short" : "AGT",
+              "long" : "agent (with ἀπό, ἐξ, πρός, ὑπό)"
+            },
+            "MNN" : {
+              "short" : "MNN",
+              "long" : "(with ἀπό, διά, ἐξ, μετά) manner"
+            },
+            "ACM" : {
+              "short" : "ACM",
+              "long" : "accompaniment (with μετά, ἄνευ)"
+            },
+            "ADG" : {
+              "short" : "ADG",
+              "long" : "advantage (with πρός)"
+            },
+            "NAB" : {
+              "short" : "NAB",
+              "long" : "none of the above"
+            },
+            "IDK" : {
+              "short" : "IDK",
+              "long" : "I don't know"
+            }
+          }
+        },
+        "UNS" : {
+          "short" : "UNS",
+          "long" : "unspecified"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "IND" : {
+      "short" : "IND",
+      "long" : "independent",
+      "sections" : "1407",
+      "nested" : {
+        "EXC" : {
+          "short" : "EXC",
+          "long" : "exclamation",
+          "sections" : "1407"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I don't know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/ind.json
+++ b/app/static/configs/sg2/sg_labels/ind.json
@@ -1,0 +1,20 @@
+{
+  "nested" : {
+    "IND" : {
+      "short" : "IND",
+      "long" : "in indirect speech"
+    },
+    "NOT_IND" : {
+      "short" : "NOT_IND",
+      "long" : "not in indirect speech"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/ind2.json
+++ b/app/static/configs/sg2/sg_labels/ind2.json
@@ -1,0 +1,24 @@
+{
+  "nested" : {
+    "IND" : {
+      "short" : "IND",
+      "long" : "in indirect speech",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "NOT_IND" : {
+      "short" : "NOT_IND",
+      "long" : "not in indirect speech",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I do not know",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/infinitives.json
+++ b/app/static/configs/sg2/sg_labels/infinitives.json
@@ -1,0 +1,133 @@
+{
+  "nested" : {
+    "INF_DPN" : {
+      "short" : "INF_DPN",
+      "long" : "dependent",
+      "nested" : {
+        "INF_ART" : {
+          "short" : "INF_ART",
+          "long" : "articular",
+          "nested" : {
+            "INF_NMN" : {
+              "short" : "INF_NMN",
+              "sections" : "2031",
+              "long" : "nominative",
+              "fileUrl" : "./static/configs/sg/sg_labels/nominative_cases.json"
+            },
+            "INF_GNT" : {
+              "short" : "INF_GNT",
+              "sections" : "2032",
+              "long" : "genitive",
+              "fileUrl" : "./static/configs/sg/sg_labels/genetive_cases.json"
+            },
+            "INF_DTV" : {
+              "short" : "INF_DTV",
+              "sections" : "2033",
+              "long" : "dative",
+              "fileUrl" : "./static/configs/sg/sg_labels/dative_cases.json"
+            },
+            "INF_ACC" : {
+              "short" : "INF_ACC",
+              "sections" : "2034",
+              "long" : "accusative",
+              "fileUrl" : "./static/configs/sg/sg_labels/accusative_cases.json"
+            },
+            "ART_NAB" : {
+              "short" : "ART_NAB",
+              "long" : "none of the above"
+            },
+            "ART_IDK" : {
+              "short" : "ART_IDK",
+              "long" : "I do not know"
+            }
+          }
+        },
+        "INF_VRB" : {
+          "short" : "INF_VRB",
+          "long" : "verbal",
+          "nested" : {
+            "INF_NMN" : {
+              "short" : "INF_NMN",
+              "long" : "with function of nominative",
+	      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+            },
+            "INF_ACC" : {
+              "short" : "INF_ACC",
+              "long" : "with function of accusative",
+	      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+            },
+            "INF_PRP" : {
+              "short" : "INF_PRP",
+              "long" : "infinitive of purpose",
+	      "sections" : "2008-2010"
+            },
+            "INF_RSL" : {
+              "short" : "INF_RSL",
+              "long" : "infinitive of result",
+	      "sections" : "2011",
+            },
+            "INF_TMP" : {
+              "short" : "INF_TMP",
+              "long" : "infinitive with πρίν",
+	      "sections" : "2453-2461"
+            },
+            "VRB_NAB" : {
+              "short" : "VRB_NAB",
+              "long" : "none of the above"
+            },
+            "VRB_IDK" : {
+              "short" : "VRB_IDK",
+              "long" : "I do not know"
+            }
+          }
+        },
+        "DPN_NAB" : {
+          "short" : "DPN_NAB",
+          "long" : "none of the above"
+        },
+        "DPN_IDK" : {
+          "short" : "DPN_IDK",
+          "long" : "I do not know"
+        }
+      }
+    },
+    "INF_IND" : {
+      "short" : "INF_IND",
+      "long" : "independent",
+      "nested" : {
+        "INF_CMM" : {
+          "short" : "INF_CMM",
+          "long" : "command"
+        },
+        "INF_WSH" : {
+          "short" : "INF_WSH",
+          "long" : "wish"
+        },
+        "INF_EXC" : {
+          "short" : "INF_EXC",
+          "long" : "exclamation"
+        },
+        "INF_ABS" : {
+          "short" : "INF_ABS",
+          "long" : "absolute infinitive"
+        },
+        "IND_NAB" : {
+          "short" : "IND_NAB",
+          "long" : "none of the above"
+        },
+        "IND_IDK" : {
+          "short" : "IND_IDK",
+          "long" : "I do not know"
+        }
+      }
+    },
+    "INF_NAB" : {
+      "short" : "INF_NAB",
+      "long" : "none of the above"
+    },
+    "INF_IDK" : {
+      "short" : "INF_IDK",
+      "long" : "I do not know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/nominative_cases.json
+++ b/app/static/configs/sg2/sg_labels/nominative_cases.json
@@ -1,0 +1,46 @@
+{
+  "nested" : {
+    "DPD" : {
+      "short" : "DPD",
+      "long" : "dependent",
+      "sections" : "940-941"
+    },
+    "INN" : {
+      "short" : "INN",
+      "long" : "independent",
+      "sections" : "938-939",
+      "nested" : {
+        "CIT" : {
+          "short" : "CIT",
+          "long" : "citation"
+        },
+        "PND" : {
+          "short" : "PND",
+          "long" : "pending (nom. pendens)",
+          "sections" : "941"
+        },
+        "EXC" : {
+          "short" : "EXC",
+          "long" : "exclamation",
+          "sections" : "1288"
+        },
+        "NAB" : {
+          "short" : "NAB",
+          "long" : "none of the above"
+        },
+        "IDK" : {
+          "short" : "IDK",
+          "long" : "I don't know"
+        }
+      }
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I don't know"
+    }
+  }
+}

--- a/app/static/configs/sg2/sg_labels/participles.json
+++ b/app/static/configs/sg2/sg_labels/participles.json
@@ -1,0 +1,22 @@
+{
+  "nested" : {
+    "ADJ_PRT" : {
+      "short" : "ADJ_PRT",
+      "long" : "adjective participle",
+      "fileUrl" : "./static/configs/sg/sg_labels/adj_prt.json"
+    },
+    "SBS_PRT" : {
+      "short" : "SBS_PRT",
+      "long" : "substantive participle",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "PRT_NAB" : {
+      "short" : "PRT_NAB",
+      "long" : "none of the above"
+    },
+    "PRT_IDK" : {
+      "short" : "PRT_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/pronouns.json
+++ b/app/static/configs/sg2/sg_labels/pronouns.json
@@ -1,0 +1,21 @@
+{
+  "nested" : {
+    "SBS_PRN" : {
+      "short" : "SBS_PRN",
+      "long" : "substantive",
+      "fileUrl" : "./static/configs/sg/sg_labels/cases.json"
+    },
+    "ADJ_PRN" : {
+      "short" : "ADJ_PRN",
+      "long" : "adjective"
+    },
+    "PRN_NAB" : {
+      "short" : "PRN_NAB",
+      "long" : "none of the above"
+    },
+    "PRN_IDK" : {
+      "short" : "PRN_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/sbs_adj_cl.json
+++ b/app/static/configs/sg2/sg_labels/sbs_adj_cl.json
@@ -1,0 +1,42 @@
+{
+  "nested" : {
+    "ORD" : {
+      "short" : "ORD",
+      "long" : "ordinary relative clause",
+      "sections" : "2553",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind2.json"
+    },
+    "FNL" : {
+      "short" : "FNL",
+      "long" : "final relative clause",
+      "sections" : "2554",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind2.json"
+    },
+    "CAU" : {
+      "short" : "CAU",
+      "long" : "cause relative clause",
+      "sections" : "2555",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind2.json"
+    },
+    "CNS" : {
+      "short" : "CNS",
+      "long" : "consecutive relative clause",
+      "sections" : "2556-2559",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind2.json"
+    },
+    "CND" : {
+      "short" : "CND",
+      "long" : "conditional relative clause",
+      "sections" : "2560-2573",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind2.json"
+    },
+    "NAB" : {
+      "short" : "NAB",
+      "long" : "none of the above"
+    },
+    "IDK" : {
+      "short" : "IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/sbs_cl.json
+++ b/app/static/configs/sg2/sg_labels/sbs_cl.json
@@ -1,0 +1,36 @@
+{
+  "nested" : {
+    "SBS_CLS_STT" : {
+      "short" : "SBS_CLS_STT",
+      "long" : "statement",
+      "sections" : "2576-2588",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "SBS_CLS_WLL" : {
+      "short" : "SBS_CLS_WLL",
+      "long" : "will or desire",
+      "sections" : "2207-2239",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "SBS_CLS_QUS" : {
+      "short" : "SBS_CLS_QUS",
+      "long" : "question",
+      "sections" : "2663-2680",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "SBS_CLS_EXC" : {
+      "short" : "SBS_CLS_EXC",
+      "long" : "exclamation",
+      "sections" : "2681-2687",
+      "fileUrl" : "./static/configs/sg/sg_labels/ind.json"
+    },
+    "SBS_CLS_NAB" : {
+      "short" : "SBS_CLS_NAB",
+      "long" : "none of the above"
+    },
+    "SBS_CLS_IDK" : {
+      "short" : "SBS_CLS_IDK",
+      "long" : "I do not know"
+    } 
+  }
+}

--- a/app/static/configs/sg2/sg_labels/verbs.json
+++ b/app/static/configs/sg2/sg_labels/verbs.json
@@ -1,0 +1,36 @@
+{
+  "nested" : {
+    "VRB_FIN" : {
+      "short" : "VRB_FIN",
+      "long" : "finite mood verb",
+      "dependency" : {
+        "pers" : "*"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/finite_verbs.json"
+    },
+    "VRB_PRT" : {
+      "short" : "VRB_PRT",
+      "long" : "participle",
+      "dependency" : {
+        "mood" : "part"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/participles.json"
+    },
+    "VRB_INF" : {
+      "short" : "VRB_INF",
+      "long" : "infinitive",
+      "dependency" : {
+        "mood" : "inf"
+      },
+      "fileUrl" : "./static/configs/sg/sg_labels/infinitives.json"
+    },
+    "VRB_NAB" : {
+      "short" : "VRB_NAB",
+      "long" : "none of the above"
+    },
+    "VRB_IDK" : {
+      "short" : "VRB_IDK",
+      "long" : "I do not know"
+    }
+  }
+}


### PR DESCRIPTION
Add @gcelano' s fixes to the SG labelset. For now we don't override the old set and keep the fixes in a distinct folder (`sg2`). In case anything goes wrong, we can switch back to the fallback in `sg`.

If everything's fine we can dump the old configuration later on.
