### PR TITLE
Double-click unusedTokenHighlighter to select them

### DIFF
--- a/app/js/arethusa.core/directives/unused_token_highlighter.js
+++ b/app/js/arethusa.core/directives/unused_token_highlighter.js
@@ -118,6 +118,9 @@ angular.module('arethusa.core').directive('unusedTokenHighlighter', [
       },
       template: '\
         <span\
+          tooltip-html-unsafe="{{ \'UNUSED_TOOLTIP\' | translate }}"\
+          tooltip-popup-delay="700"\
+          tooltip-placement="left"\
           translate="UNUSED_COUNT"\
           translate-value-count="{{ unusedCount }}"\
           translate-value-total="{{ total }}">\

--- a/app/static/i18n/en.json
+++ b/app/static/i18n/en.json
@@ -2,5 +2,6 @@
   "SEARCH_DOCUMENTS": "Search for documents",
   "LANGUAGE": "Language",
   "UNUSED_COUNT": "{{ count }} of {{ total }} unused",
+  "UNUSED_TOOLTIP": "Click to toggle highlighting<br>Double-click to select",
   "help" : "Help"
 }

--- a/app/templates/dep_tree.html
+++ b/app/templates/dep_tree.html
@@ -9,9 +9,6 @@
     <span
       class="note clickable right margined-hor-tiny flash-on-hover"
       style="margin-left: 10px"
-      tooltip-html-unsafe="Click to toggle highlighting<br>Double-click to select"
-      tooltip-popup-delay="700"
-      tooltip-placement="left"
       unused-token-highlighter
       uth-check-property="head.id">
     </span>

--- a/app/templates/relation.html
+++ b/app/templates/relation.html
@@ -14,9 +14,6 @@
 <div
   class="note clickable right margined-hor-tiny flash-on-hover"
   style="margin-top: 10px"
-  tooltip="Click to highlight unused tokens"
-  tooltip-popup-delay="700"
-  tooltip-placement="left"
   unused-token-highlighter
   uth-check-property="relation.label">
 </div>


### PR DESCRIPTION
Title says pretty much all. Sometimes nice to quick-select all unused tokens - we can dblclick `uTH` now to achieve that.

The tooltip to indicate what `uTH` is doing was inlined and is fully compliant with `angular-translate`.
