### PR TITLE
Toggling foreignKeys

### DIFF
--- a/app/js/arethusa.core/directives/foreign_keys.js
+++ b/app/js/arethusa.core/directives/foreign_keys.js
@@ -119,6 +119,7 @@ angular.module('arethusa.core').directive('foreignKeys',[
           } else {
             element.unbind('keydown', scope.parseEvent);
           }
+          element.attr('placeholder', placeHolderText);
         });
       }
     };


### PR DESCRIPTION
Adds a toggle button to disable/enable the `foreignKeys` directive. Long planned, but recently also requested by Francesco Mambrini.
