### PR TITLE
Deactivate the spinner

### DIFF
--- a/app/js/arethusa.core/resource.js
+++ b/app/js/arethusa.core/resource.js
@@ -81,16 +81,16 @@ angular.module('arethusa.core').factory('Resource', [
       this.resource = createResource();
 
       this.get = function (otherParams) {
-        spinner.spin();
+        //spinner.spin();
         var params = collectedParams(self.params, otherParams);
         var promise = self.resource.get(params).$promise;
-        promise['finally'](spinner.stop);
+        //promise['finally'](spinner.stop);
         return promise;
       };
 
       var authFailure;
       this.save = function (data,mimetype) {
-        spinner.spin();
+        //spinner.spin();
 
         var params = collectedParams(self.params,{});
         self.mimetype = mimetype;
@@ -102,7 +102,7 @@ angular.module('arethusa.core').factory('Resource', [
           return self.resource.save(params, data).$promise;
         });
 
-        promise['finally'](spinner.stop);
+        //promise['finally'](spinner.stop);
         return promise;
       };
 

--- a/app/templates/navbar1.html
+++ b/app/templates/navbar1.html
@@ -9,7 +9,6 @@
       <ul navbar-search/>
       <ul navbar-navigation/>
       <ul navbar-buttons class="right"/>
-      <ul spinner class="right" style="margin-top: 13px"/>
     </section>
   </nav>
 </div>


### PR DESCRIPTION
Not really worth an own PR, but so that it's easier looked up again:

The spinner in the navbar has been deactivated. It was confusing users at times and it had visual bugs in some browsers.

Better to use more notifications (#358) if we need to tell he user that something is loading.
