### PR TITLE
Update citations at the right time

### DIFF
--- a/app/js/arethusa.core/navigator.js
+++ b/app/js/arethusa.core/navigator.js
@@ -225,10 +225,10 @@ angular.module('arethusa.core').service('navigator', [
 
     this.updateId = function () {
       updateNextAndPrev();
-      updateCitation();
       updateChunks();
       self.status.currentPos = self.currentPosition;
       self.status.currentIds = currentIds();
+      updateCitation();
     };
 
     this.sentenceToString = function(sentence) {


### PR DESCRIPTION
We were updating before the sentence identifiers were updates - which means that we were always of by one step, which was not only wrong but also confusing for users.
