### PR TITLE
Add ability to skip auth in specific modes

### DIFF
--- a/app/js/arethusa.core/auth.js
+++ b/app/js/arethusa.core/auth.js
@@ -30,11 +30,16 @@ angular.module('arethusa.core').factory('Auth', [
     var translations = {};
     translator('auth.notLoggedIn', translations, 'notLoggedIn');
 
-    return function(conf) {
+    return function(conf, modeFn) {
       var self = this;
       self.conf = conf;
+      var skipModes = conf.skipModes || [];
 
       var authFailure;
+
+      function modeToSkip() {
+        return arethusaUtil.isIncluded(skipModes, modeFn());
+      }
 
       function loginWarning() {
         authFailure = true;
@@ -48,6 +53,7 @@ angular.module('arethusa.core').factory('Auth', [
       var pinger = new Pinger(conf.ping);
 
       this.checkAuthentication = function() {
+        if (modeToSkip()) return;
         pinger.checkAuth(noop, checkForAuthFailure);
       };
 
@@ -68,7 +74,7 @@ angular.module('arethusa.core').factory('Auth', [
 
         // If we had no authFailure before, avoid the indirection and
         // launch the callback right away.
-        if (!authFailure) {
+        if (!authFailure || modeToSkip()) {
           launch();
         } else {
           // Check auth will ideally restore our session cookie - we need to

--- a/app/js/arethusa.core/configurator.js
+++ b/app/js/arethusa.core/configurator.js
@@ -321,7 +321,7 @@ angular.module('arethusa.core').service('configurator', [
     }
 
     this.provideAuth = function(name) {
-      return new Auth(auths()[name] || {});
+      return new Auth(auths()[name] || {}, self.mode);
     };
 
     this.addPluginConf = function(name, conf) {

--- a/app/static/configs/auths/perseids.json
+++ b/app/static/configs/auths/perseids.json
@@ -3,6 +3,9 @@
     "type": "CSRF",
     "cookie": "csrftoken",
     "header": "X-CSRF-Token",
-    "ping" : "http://sosol.perseids.org/sosol/dmm_api/ping"
+    "ping" : "http://sosol.perseids.org/sosol/dmm_api/ping",
+    "skipModes" : [
+      "viewer"
+    ]
   }
 }


### PR DESCRIPTION
The configurator knows the general active mode and exposes a function to check for it.
It's also the only place to instantiate Auth instances.

Auth instances can now be configured with an array of `skipModes` - modes where the authentication routine is circumvented.

The configurator passes the mode function to the Auth instance, so that it can check if authentication is required or not.

Check how the perseids authentication configuration does it.

Closes #458
