### PR TITLE
don't do an inventory lookup if the form doesn't have a lexInvLocation

### DIFF
--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -114,7 +114,7 @@ angular.module('arethusa.morph').service('morph', [
     }
 
     function getDataFromInventory(form) {
-      if (inventory) {
+      if (inventory && form.lexInvLocation) {
         var urn = form.lexInvLocation.urn;
         inventory.getData(urn, form);
       }


### PR DESCRIPTION
if the morphology retriever is configured to do lexical inventory lookups, but the form doesn't actually have a urn to lookup (which can occur if the lexical inventory service is down, but also could be the case for forms which don't have them) then we fail to display the morphology service results because this code wasn't returning because form.lexInvLocation was undefined.
