### PR TITLE
Listen to tokenAdded/Removed events in navigator - fix #405

### DIFF
--- a/app/js/arethusa.core/navigator.js
+++ b/app/js/arethusa.core/navigator.js
@@ -305,7 +305,9 @@ angular.module('arethusa.core').service('navigator', [
     };
 
     // Probably could deregister/reregister that watch, but it doesn't hurt...
-    $rootScope.$on('tokenChange', self.markChunkChanged);
+    $rootScope.$on('tokenChange',  self.markChunkChanged);
+    $rootScope.$on('tokenAdded',   self.markChunkChanged);
+    $rootScope.$on('tokenRemoved', self.markChunkChanged);
     $rootScope.$on('layoutChange', resetList);
   }
 ]);


### PR DESCRIPTION
The current chunk wasn't marked as being updated, so the persisters couldn't update their source documents.
