### PR TITLE
Don't allow pers and num for infinitives

### DIFF
--- a/app/static/configs/morph/gr_attributes2.json
+++ b/app/static/configs/morph/gr_attributes2.json
@@ -130,7 +130,7 @@
             "mood" : "*"
           },
           "unless" : {
-            "mood" : "part"
+            "mood" : [ "part", "inf" ]
           }
         }
       ]
@@ -148,6 +148,9 @@
           "if" : {
             "pos" : "verb",
             "mood" : "*"
+          },
+          "unless" : {
+            "mood" : "inf"
           }
         }
       ],

--- a/app/static/configs/morph/lat_attributes.json
+++ b/app/static/configs/morph/lat_attributes.json
@@ -130,7 +130,7 @@
             "mood" : "*"
           },
           "unless" : {
-            "mood" : "part"
+            "mood" : [ "part", "inf" ]
           }
         }
       ]
@@ -148,6 +148,9 @@
           "if" : {
             "pos" : "verb",
             "mood" : "*"
+          },
+          "unless" : {
+            "mood" : "inf"
           }
         }
       ],


### PR DESCRIPTION
Fixes #487 

Theses changes also have to be made in the https://github.com/latin-language-toolkit/arethusa-configs - it might be generally good to re-import the greek attribute set from there, as the local version is out of sync by now.
