### PR TITLE
prevent undefined exception on undo of attach new aT

### DIFF
--- a/app/js/arethusa.core/tree.js
+++ b/app/js/arethusa.core/tree.js
@@ -661,6 +661,12 @@ angular.module('arethusa.core').factory('Tree', [
         return scope.current[id];
       }
 
+      function isDisconnected(val) {
+        // The new head value might be undefined or set to an
+        // empty string to indicate disconnection.
+        return !(angular.isDefined(val) && val !== "");
+      }
+
       // only do this if we are the main tree!
       if (isMainTree()) {
         state.on('tokenAdded', function(event, token) {
@@ -691,9 +697,7 @@ angular.module('arethusa.core').factory('Tree', [
             if (newVal !== oldVal) {
               // If a disconnection has been requested, we just
               // have to delete the edge and do nothing else
-              // if it's a previously unattached artificial token and this is an 
-              // undo action the newVal will be undefined
-              if (!(angular.isDefined(newVal)) || newVal === "") {
+              if (isDisconnected(newVal)) {
                 self.g.delEdge(token.id);
               } else {
                 updateEdge(token);


### PR DESCRIPTION
trying to clean up uncaught exceptions around handling of artificial tokens --- this fixes one that occurred on undo of an attach of a new artificial token to a head.  The redrawing of the edge on the undo was throwing an exception when the head.id was undefined.
