### PR TITLE
Initialize empty morphology obj on tokenAdded

### DIFF
--- a/app/js/arethusa.morph/morph.js
+++ b/app/js/arethusa.morph/morph.js
@@ -654,6 +654,7 @@ angular.module('arethusa.morph').service('morph', [
       var id = token.id;
       var forms = new Forms(token.string);
       self.analyses[id] = forms;
+      token.morphology = {};
       loadToken(forms, id);
     });
 


### PR DESCRIPTION
Fixes #556 

The morphology plugin needs to prepare an added token so that it's own functions - as called by the context menu - don't throw exceptions.
