### PR TITLE
refactoring requires new version of arethusa-cli tools

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -503,7 +503,7 @@ module.exports = function(grunt) {
         command: [
           'bower install',
           'gem install sass -v 3.3.14',
-          'gem install arethusa-cli'
+          'gem install arethusa-client -v 0.1.17'
         ].join('&&')
       },
       e2eSetup: {


### PR DESCRIPTION
@fbaumgardt I think your changes require the fix to arethusa-cli, so in the interest of expediency, I went ahead and published the changes to that gem under a new name.  We'll obsolete it eventually but this is the simplest route for now. Let me know if you see any reason not to do this.

(I was hoping this would have also fixed some of the broken tests -- will investigate and address those in another PR)