### PR TITLE
Allow scrolling in sentence list

### DIFF
--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -13,12 +13,15 @@ html, body {
 }
 
 #canvas {
-  overflow: hidden;
   width: 100%;
 }
 
 .scrollable {
   overflow: auto;
+}
+
+.not-scrollable {
+  overflow: hidden;
 }
 
 #sidepanel {

--- a/app/js/templates/exercise_demo.html
+++ b/app/js/templates/exercise_demo.html
@@ -1,6 +1,6 @@
 <arethusa-navbar></arethusa-navbar>
 <p/>
-<div id="canvas" class="row panel full-height" full-height>
+<div id="canvas" class="row panel full-height not-scrollable" full-height>
   <div id="main-body" class="columns small-7">
     <div ng-repeat="pl in mainPlugins">
       <plugin name="pl"/>

--- a/app/js/templates/main_with_sidepanel.html
+++ b/app/js/templates/main_with_sidepanel.html
@@ -2,7 +2,7 @@
   <div id="arethusa-editor">
     <div class="canvas-border"/>
 
-    <div id="canvas" class="row panel full-height" full-height>
+    <div id="canvas" class="row panel full-height not-scrollable" full-height>
       <div id="main-body" to-bottom>
         <div ng-repeat="pl in plugins.main" plugin name="{{ pl.name }}"/>
         <div keys-to-screen/>


### PR DESCRIPTION
Allow a user to scroll down when viewing a list of sentences if there are too many to fit on the screen.

Scrolling was not working previously (at least on Chrome) because the `#canvas` id's CSS included `overflow: hidden` which was overriding the `overflow: auto` in the `.scrollable` class.

To see an example of the scrolling issue, visit https://www.perseids.org/tools/arethusa/app/#/perseids?chunk=1&doc=53118 then hover over "1" and click "List"  and try to scroll (see screenshot).

<img width="589" alt="screenshot" src="https://user-images.githubusercontent.com/3039310/38271967-e91aa242-3755-11e8-823d-6ca3301bf9de.png">
