### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - "4.2.6"
 addons:
   sauce_connect:
     username: "balmas"

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "grunt-contrib-sass": "0.7.3",
     "grunt-contrib-uglify": "0.4.0",
     "grunt-contrib-watch": "0.6.1",
-    "grunt-coveralls": "0.3.0",
+    "grunt-coveralls": "1.0.1",
     "grunt-githooks": "^0.3.1",
     "grunt-karma": "0.8.0",
     "grunt-newer": "alpheios-project/grunt-newer",
     "grunt-ngdocs": "alpheios-project/grunt-ngdocs#links_to_source_code",
     "grunt-protractor-runner": "1.0.0",
-    "grunt-sauce-connect-launcher": "~0.3.0",
+    "grunt-sauce-connect-launcher": "0.3.1",
     "grunt-shell": "0.7.0",
     "karma": "0.12.0",
     "karma-chrome-launcher": "0.1.3",
@@ -51,6 +51,6 @@
     "grunt-bump": "0.0.16"
   },
   "scripts": {
-    "test": "grunt karma:spec coveralls jshint"
+    "test": "grunt --stack karma:spec coveralls jshint"
   }
 }


### PR DESCRIPTION
Make the following changes to fix Travis CI errors: 

- Tests were failing on CI due to [this issue](https://github.com/nickmerwin/node-coveralls/issues/69) in `node-coveralls`. Although the issue was fixed in `node-coveralls` [2.11.2](https://github.com/nickmerwin/node-coveralls/pull/70#issuecomment-56322042), we were using `grunt-coveralls` 0.3.0, which [uses](https://github.com/pimterry/grunt-coveralls/blob/v0.3.0/package.json#L54) `node-coveralls` version `~2.7.0`. In order to fix the issue, bump the version of `grunt-coveralls`.

- For some reason, `sauce_connect.js` was producing the error `Unexpected token ILLEGAL`.  Lock the version of `grunt-sauce-connect-launcher` and use Node ~4 to fix the issue.

- To help debugging in the future, run `grunt` with the `--stack` flag when running `npm test`. The `--stack` flag causes Grunt to include a stack trace when it exits with an error.

