### PR TITLE
Show overflowing items

### DIFF
--- a/app/css/arethusa.scss
+++ b/app/css/arethusa.scss
@@ -9,7 +9,6 @@
 
 html, body {
   height: 100%;
-  overflow: hidden;
 }
 
 #canvas {

--- a/app/js/arethusa.core/directives/fullHeight.js
+++ b/app/js/arethusa.core/directives/fullHeight.js
@@ -10,11 +10,12 @@ angular.module('arethusa.core').directive('fullHeight', [
         var body = angular.element(document.body);
         var border = angular.element(document.getElementById('canvas-border')).height();
         var margin = element.css("margin-bottom").replace('px', '');
+        var padding = element.css("padding-bottom").replace('px', '');
         var additionalBorder = attrs.fullHeight || 0;
 
         function resize(args) {
           var fullHeight = body.height();
-          element.height(fullHeight - margin - additionalBorder);
+          element.height(fullHeight - margin - padding - additionalBorder);
         }
         win.bind('resize', function() {
           resize();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   web:
     build: .
+    volumes:
+      - ./app:/arethusa/app
     command: ["grunt", "reloading-server", "--port=$${PORT}"]
     ports:
       - "8081:8081"


### PR DESCRIPTION
Previously, when a tooltip appeared near the bottom of the screen it would get cut off, making it impossible for the user to interact with it (see first screenshot below). To prevent this from happening, this PR removes `overflow: hidden` from `body` and `html` in the CSS (see second screenshot below).

Making this change uncovered a bug in the `fullHeight.js` directive: it was ignoring padding. This PR also fixes that bug.

These changes together mean that there is no scroll bar until a tooltip overflows, and when that happens, a scrollbar appears and the user can interact with the tooltip.

(Also included, a tweak to the Docker Compose config to make developing easier)

---

Tooltip cut off:

<img width="1157" alt="before" src="https://user-images.githubusercontent.com/3039310/47234261-3ceb8c80-d3a3-11e8-906a-e6cd93ff199f.png">

---

Scrolling down:

<img width="1157" alt="after" src="https://user-images.githubusercontent.com/3039310/47234270-44129a80-d3a3-11e8-8982-75732d4ddb50.png">
