### PR TITLE
Show URN when API call fails

### DIFF
--- a/app/js/arethusa.core/services/navigator.js
+++ b/app/js/arethusa.core/services/navigator.js
@@ -31,10 +31,12 @@ angular.module('arethusa.core').service('navigator', [
       var sec = citeSplit[1];
       citation = citationCache.get(doc);
       if (! citation) {
-        citeMapper.get({ cite: doc}).then(function(res) {
+        citeMapper.get({ cite: doc }).then(function(res) {
           citation = res.data;
           citationCache.put(doc, citation);
           callback(citationToString(citation, sec));
+        }).catch(function() {
+          callback(cite);
         });
       } else {
         callback(citationToString(citation, sec));


### PR DESCRIPTION
When the API call to the cite mapper to find the name of a work fails (because it's not in Perseus or for any other reason), then show the URN in the title field, which is how `document_id`s that are not URNs are treated.

Previously, if the API call failed, the field would be blank.

---

Before:

<img width="799" alt="before" src="https://user-images.githubusercontent.com/3039310/47568615-96057400-d8ff-11e8-99cd-7705b80ee73a.png">

---

After:

<img width="797" alt="after" src="https://user-images.githubusercontent.com/3039310/47568611-9140c000-d8ff-11e8-819d-81ca377656b0.png">
