### PR TITLE
Fix bug in forms sorted by frequency

### DIFF
--- a/app/js/arethusa.morph/services/morph_local_storage.js
+++ b/app/js/arethusa.morph/services/morph_local_storage.js
@@ -263,7 +263,7 @@ angular.module('arethusa.morph').service('morphLocalStorage', [
       return _.map(counts, function(v, k) {
         return [k, v];
       }).sort(function(a, b) {
-        return a[1] < b[1];
+        return b[1] - a[1];
       });
     }
 

--- a/spec/arethusa.morph/morph_local_storage_spec.js
+++ b/spec/arethusa.morph/morph_local_storage_spec.js
@@ -174,7 +174,7 @@ describe("morphLocalStorage", function() {
 
   describe('this.sortByPreference', function() {
     it('sorts form preferences', function() {
-      var imported = '1$$ma|-|a1@@3;;mas|-|b1@@2';
+      var imported = '1$$mas|-|b1@@2;;ma|-|a1@@3';
       morphLocalStorage.addPreferences('mare',imported);
       var formsToSort =  [ { lemma: 'mas', postag: 'b1' }, {lemma: 'ma', postag: 'a1'}, {lemma: 'mas', postag: 'c1'} ];
       var sorted = morphLocalStorage.sortByPreference('mare',formsToSort);


### PR DESCRIPTION
The `morphLocalStorage` module provides functionality to sort forms based on the frequency they are chosen by a user. Due to a bug in `toSortedArray`, however, the forms were never actually being sorted. The result was that the form that was used first would always appear first in the list, the one that was used second would be second, etc.

This PR fixes the issue so that forms are sorted based on frequency.