### PR TITLE
Small fixes for compatibility with the Perseids Treebank Template

### DIFF
--- a/app/js/arethusa.core/directives/fullHeight.js
+++ b/app/js/arethusa.core/directives/fullHeight.js
@@ -17,9 +17,6 @@ angular.module('arethusa.core').directive('fullHeight', [
           var fullHeight = body.height();
           element.height(fullHeight - margin - padding - additionalBorder);
         }
-        win.bind('resize', function() {
-          resize();
-        });
 
         resize();
       }

--- a/app/js/arethusa.core/services/api.js
+++ b/app/js/arethusa.core/services/api.js
@@ -49,6 +49,14 @@ angular.module('arethusa.core').service('api', [
       return this.outputter.outputMorph(state.getToken(idHandler.getId(wordId,sentenceId)),lang(),morph());
     };
 
+    /**
+     * returns subdoc of the current sentence
+     * @return {String} the subdoc of the current sentence (may also be undefined or '')
+     */
+    this.getSubdoc = function() {
+      return navigator.currentSubdocs()[0];
+    };
+
     /** 
      * rerenders the tree
      * can be useful to call the tree is first loaded in a iframe that isn't visible

--- a/app/js/arethusa.core/services/navigator.js
+++ b/app/js/arethusa.core/services/navigator.js
@@ -95,6 +95,9 @@ angular.module('arethusa.core').service('navigator', [
     function currentIds () {
       return arethusaUtil.map(currentSentenceObjs(), 'id');
     }
+    this.currentSubdocs = function() {
+      return arethusaUtil.map(currentSentenceObjs(), 'subdoc');
+    }
     this.sentenceToString = function(sentence) {
       return arethusaUtil.inject([], sentence.tokens, function(memo, id, token) {
         memo.push(token.string);

--- a/app/js/arethusa.dep_tree/services/dep_tree.js
+++ b/app/js/arethusa.dep_tree/services/dep_tree.js
@@ -31,7 +31,7 @@ angular.module('arethusa.depTree').service('depTree', [
 
     this.externalDependencies = {
       ordered: [
-        "../../vendor/d3-3.4.13/d3.js",
+        "../../vendor/d3-3.4.13/d3.min.js",
         window.dagred3path
       ]
     };

--- a/app/js/arethusa.util/services/commons.js
+++ b/app/js/arethusa.util/services/commons.js
@@ -71,11 +71,12 @@ angular.module('arethusa.util').service('commons', [
     this.doc = function(x, j, c) { return new Doc(x, j, c); };
 
     // Used by retrievers to define sentences
-    function Sentence(tokens, cite) {
+    function Sentence(tokens, cite, subdoc) {
       var self = this;
 
       this.tokens = tokens;
       this.cite = cite || '';
+      this.subdoc = subdoc || '';
 
       this.toString = function() {
         return arethusaUtil.inject([], self.tokens, function(memo, id, token) {
@@ -93,7 +94,7 @@ angular.module('arethusa.util').service('commons', [
      * TODO
      *
      */
-    this.sentence = function(t, cite) { return new Sentence(t, cite); };
+    this.sentence = function(t, cite, subdoc) { return new Sentence(t, cite, subdoc); };
 
     // Used by retrievers to define constituents
     function Constituent(cl, role, id, sentenceId, parentId) { // might want to add more here

--- a/app/js/arethusa/factories/treebank_retriever.js
+++ b/app/js/arethusa/factories/treebank_retriever.js
@@ -37,12 +37,13 @@ angular.module('arethusa').factory('TreebankRetriever', [
     function parseSentences(sentences, docId) {
       return sentences.map(function(sentence) {
         var cite = extractCiteInfo(sentence);
+        var subdoc = sentence._subdoc || '';
         var words = arethusaUtil.toAry(sentence.word);
-        return parseSentence(sentence, sentence._id, docId, cite);
+        return parseSentence(sentence, sentence._id, docId, cite, subdoc);
       });
     }
 
-    function parseSentence(sentence, id, docId, cite) {
+    function parseSentence(sentence, id, docId, cite, subdoc) {
       var words = aU.toAry(sentence.word);
       var tokens = {};
 
@@ -55,7 +56,7 @@ angular.module('arethusa').factory('TreebankRetriever', [
         tokens[token.id] = token;
       });
 
-      var sentenceObj = commons.sentence(tokens, cite);
+      var sentenceObj = commons.sentence(tokens, cite, subdoc);
       retrieverHelper.generateId(sentenceObj, id, id, docId);
 
       return sentenceObj;

--- a/deploy_widget.sh
+++ b/deploy_widget.sh
@@ -4,12 +4,12 @@ then
   deploy_dir=dist_widget
 fi
 echo "Deploying to $deploy_dir"
-if [ ! -e $deploy_dir ]
-then
-  mkdir $deploy_dir
-  mkdir $deploy_dir/dist
-fi
+
+mkdir -p $deploy_dir/dist
+mkdir -p $deploy_dir/../vendor/d3-3.4.13/
+
 cp dist/arethusa.min.js $deploy_dir
 cp dist/arethusa.min.map $deploy_dir
 cp dist/arethusa_packages.min.js $deploy_dir/arethusa.packages.min.js
 cp dist/* $deploy_dir/dist
+cp vendor/d3-3.4.13/d3.min.js $deploy_dir/../vendor/d3-3.4.13/d3.min.js


### PR DESCRIPTION
* Remove `resize` functionality because it results in an infinitely resizing canvas when the user changes the page width.
* Add `getSubdoc` to the API to support https://github.com/perseids-publications/treebank-template/pull/11
* Add d3 to deploy script