### PR TITLE
fix #793

### DIFF
--- a/app/js/arethusa.core/controllers/arethusa_ctrl.js
+++ b/app/js/arethusa.core/controllers/arethusa_ctrl.js
@@ -82,7 +82,7 @@ angular.module('arethusa.core').controller('ArethusaCtrl', [
         plugins.start(conf.plugins).then(function() {
           state.arethusaLoaded = true;
           notifier.success(translations.loadComplete());
-
+          angular.element(document.body)[0].dispatchEvent(new CustomEvent("ArethusaLoaded",{detail: { currentTokenCount: state.totalTokens } }));
           if (aU.isArethusaMainApplication()) {
             UserVoice.push(['addTrigger', '#uservoicebutton', { mode: 'contact' }]);
           }

--- a/app/js/arethusa.core/services/api.js
+++ b/app/js/arethusa.core/services/api.js
@@ -33,6 +33,15 @@ angular.module('arethusa.core').service('api', [
       return lazyLang;
     }
 
+
+    /** 
+     * check ready state
+     * @return {Boolean} true if arethusa is loaded and ready otherwise false
+     */
+    this.isReady = function () {
+      return state.arethusaLoaded
+    };
+
     /**
      * get the morphology and gloss for a specific word
      * @param {String} sentenceId sentence (chunk) identifier
@@ -42,10 +51,6 @@ angular.module('arethusa.core').service('api', [
      *                  (i.e. the same format as parsed by the BSPMorphRetriever)
      */
     this.getMorph = function(sentenceId,wordId) {
-      /** TODO figure out how to be sure the api service is only instantiated after Arethusa is loaded **/
-      if (!state.arethusaLoaded) {
-        console.error("Api called before Arethusa was loaded")
-      }
       return this.outputter.outputMorph(state.getToken(idHandler.getId(wordId,sentenceId)),lang(),morph());
     };
 


### PR DESCRIPTION
I'm not sure if this is really the best way to do this, but this change causes the custom ArethusaLoaded event to be dispatched to the document body when Arethusa is fully loaded.

The event detail object contains a currentTokenCount property set the number of tokens in the currently loaded chunk. Not sure that's of any use really, but it does confirm that something is there in the state.

I've also added an api call which can be used to check the state, although I'm not sure how useful it is since you would need to listen to the event anyway.

Let me know what you think and if you have requests for how I can do this differently.
