### PR TITLE
Configure Arethusa to ignore location changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,7 +143,7 @@ Z.fun = {
         "./bower_components/angular-uuid2/dist/angular-uuid2.min.js",
         //"./vendor/angular-foundation-colorpicker/js/foundation-colorpicker-module.min.js",
         "./vendor/uservoice/uservoice.min.js",
-        //"./vendor/angularJS-toaster/toaster.min.js",
+        "./vendor/angularJS-toaster/toaster.min.js",
         "./bower_components/angular-highlightjs/angular-highlightjs.min.js",
         "./bower_components/angular-drag-and-drop-lists/angular-drag-and-drop-lists.min.js",
         "./vendor/highlight/highlight.pack.js"

--- a/app/js/arethusa.js
+++ b/app/js/arethusa.js
@@ -46,6 +46,19 @@ angular.module('arethusa').config([
 
     localStorageServiceProvider.setPrefix('arethusa');
   },
+]).config([
+  // This config prevents URL changes done using the browser's History API
+  // from causing Angular to enter an infinite loop.
+  // See https://stackoverflow.com/questions/18611214/turn-off-url-manipulation-in-angularjs
+  '$provide',
+  function ($provide) {
+    $provide.decorator('$browser', ['$delegate', function ($delegate) {
+      $delegate.onUrlChange = function () {};
+      $delegate.url = function () { return '' };
+
+      return $delegate;
+    }]);
+  }
 ]);
 
 angular.module('arethusa').value('CONF_PATH', '/configs');

--- a/deploy_widget.sh
+++ b/deploy_widget.sh
@@ -10,5 +10,6 @@ mkdir -p $deploy_dir/../vendor/d3-3.4.13/
 
 cp dist/arethusa.min.js $deploy_dir
 cp dist/arethusa.min.map $deploy_dir
+cp dist/arethusa_packages.min.js $deploy_dir/arethusa.packages.min.js
 cp dist/* $deploy_dir/dist
 cp vendor/d3-3.4.13/d3.min.js $deploy_dir/../vendor/d3-3.4.13/d3.min.js


### PR DESCRIPTION
Configure Arethusa so that it ignores changes to the URL caused by the History API.

This change allows us to use the normal `arethusa.packages.min.js` file instead of patching it by hand.