### PR TITLE
refresh should set to perfect width

### DIFF
--- a/app/js/arethusa.core/factories/tree.js
+++ b/app/js/arethusa.core/factories/tree.js
@@ -742,6 +742,7 @@ angular.module('arethusa.core').factory('Tree', [
       // refreshing will rerender it and fix display bugs
       navigator.onRefresh(function() {
         render();
+        scope.perfectWidth();
         $timeout(applyViewMode, transitionDuration);
       });
 


### PR DESCRIPTION
I'd like refreshView to also set the width of the tree to the correct width for the page. Using the perfectWidth function seems to do this.

