### PR TITLE
fix #800

### DIFF
--- a/app/js/arethusa.search/services/search.js
+++ b/app/js/arethusa.search/services/search.js
@@ -229,46 +229,44 @@ angular.module('arethusa.search').service('search', [
       var combine = 0;
       // latin enclytics usually are preceded with a '-' and may be
       // either right after the base word or shifted to right before it
-      if (!match && wordANext && wordANext.match(/^-/)) {
-        match = compareWords(wordA + wordANext.replace(/^-/,''),wordB);
+      if (!match && wordANext) {
+        var cleanWordANext = wordANext.replace(/^-/,'').replace(/-$/,'');
+        match = compareWords(wordA + cleanWordANext,wordB);
         if (match) {
           combine = 1;
         }
       }
-      if (!match ) {
+      if (!match && wordAPrev) {
+        var cleanWordAPrev = wordAPrev.replace(/^-/,'').replace(/-$/,'');
         // greek krasis is postfixed with a - and should appear before the
         // base word
-        if (wordAPrev && wordAPrev.match(/-$/)) {
-          match = compareWords(wordAPrev.replace(/-$/,'') + wordA, wordB);
-        } else if (wordAPrev && wordAPrev.match(/^-/)) {
-           // handles the case where the enclytic is shifted to before the word
-           match = compareWords(wordA + wordAPrev.replace(/^-/,''),wordB);
+        if (wordAPrev) {
+          match = compareWords(cleanWordAPrev + wordA, wordB);
+          if (!match) {
+            // handles the case where the enclytic is shifted to before the word
+            match = compareWords(wordA + cleanWordAPrev, wordB);
+          }
         }
         if (match) {
           combine = -1;
         }
       }
       // recheck to see if the word we're testing is the enclytic
-      if (!match && (wordA.match(/^-/) || wordA.match(/-$/))) {
-        var testWord;
-        if (wordA.match(/^-/)) {
-          wordA = wordA.replace(/^-/,'');
-        } else {
-          wordA = wordA.replace(/-$/,'');
-        }
+      if (!match) {
+        var cleanWordA = wordA.replace(/^-/,'').replace(/-$/,'');
         if (wordAPrev) {
-          match = compareWords(wordAPrev + wordA,wordB);
+          match = compareWords(wordAPrev + cleanWordA,wordB);
           if (!match) {
-            match = compareWords(wordA + wordAPrev,wordB);
+            match = compareWords(cleanWordA + wordAPrev,wordB);
           }
           if (match) {
             combine = -1;
           }
         }
         if (! match && wordANext) {
-          match = compareWords(wordA + wordANext,wordB);
+          match = compareWords(cleanWordA + wordANext,wordB);
           if (!match) {
-            match = compareWords(wordANext + wordA,wordB);
+            match = compareWords(wordANext + cleanWordA,wordB);
           }
           if (match) {
             combine = 1;

--- a/app/js/arethusa.search/services/search.js
+++ b/app/js/arethusa.search/services/search.js
@@ -215,6 +215,16 @@ angular.module('arethusa.search').service('search', [
     return finalMatches;
    };
 
+
+    /**
+     * strip enclytic/proclytic markers from a word
+     * @param {String} word
+     * @return {String} the stripped word
+     */
+    function stripEnclytics(word) {
+      return word.replace(/^-/,'').replace(/-$/,'');
+    }
+
     /**
      * compare two words, account for the fact that wordB may be represented by a combination
      * of wordA with an enclytic that appears before or after it
@@ -230,14 +240,14 @@ angular.module('arethusa.search').service('search', [
       // latin enclytics usually are preceded with a '-' and may be
       // either right after the base word or shifted to right before it
       if (!match && wordANext) {
-        var cleanWordANext = wordANext.replace(/^-/,'').replace(/-$/,'');
+        var cleanWordANext = stripEnclytics(wordANext);
         match = compareWords(wordA + cleanWordANext,wordB);
         if (match) {
           combine = 1;
         }
       }
       if (!match && wordAPrev) {
-        var cleanWordAPrev = wordAPrev.replace(/^-/,'').replace(/-$/,'');
+        var cleanWordAPrev = stripEnclytics(wordAPrev);
         // greek krasis is postfixed with a - and should appear before the
         // base word
         if (wordAPrev) {
@@ -253,7 +263,7 @@ angular.module('arethusa.search').service('search', [
       }
       // recheck to see if the word we're testing is the enclytic
       if (!match) {
-        var cleanWordA = wordA.replace(/^-/,'').replace(/-$/,'');
+        var cleanWordA = stripEnclytics(wordA);
         if (wordAPrev) {
           match = compareWords(wordAPrev + cleanWordA,wordB);
           if (!match) {

--- a/spec/arethusa.search/search_spec.js
+++ b/spec/arethusa.search/search_spec.js
@@ -243,6 +243,23 @@ describe('search', function() {
       expect(ids[0]).toEqual('01');
       expect(ids[1]).toEqual('08');
     });
+    it('finds a word with unmarked enclytics', function() {
+      state.tokens['04'].string = 'que';
+      search.init();
+      var ids = search.queryWordInContext('virumque','Arma','cano');
+      expect(ids.length).toEqual(2);
+      expect(ids[0]).toEqual('03');
+      expect(ids[1]).toEqual('04');
+    });
+    it('finds a word with shifted unmarked enclytics', function() {
+      state.tokens['03'].string = 'que';
+      state.tokens['04'].string = 'virum';
+      search.init();
+      var ids = search.queryWordInContext('virumque','Arma','cano');
+      expect(ids.length).toEqual(2);
+      expect(ids[0]).toEqual('03');
+      expect(ids[1]).toEqual('04');
+    });
   });
 
   // This function has been made private


### PR DESCRIPTION
It turns out that at least in the Alpheios treebank data files, the enclytic/proclytic isn't always marked with a - . I can't really see any harm in testing the next/previous word whether or not it has a hyphen, can you?