### PR TITLE
Deploy script updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -625,6 +625,7 @@ module.exports = function(grunt) {
   // These three server tasks are usually everything you need!
   grunt.registerTask('server', ['clean:dist', 'version', 'minify:all', 'express:server']);
   grunt.registerTask('reloading-server', ['clean:dist', 'version', 'concurrent:server']);
+  grunt.registerTask('build', ['clean:dist', 'version', 'minify:all']);
   grunt.registerTask('doc-server', ['concurrent:docs']);
 
   grunt.registerTask('reloader', 'concurrent:watches');

--- a/app/js/arethusa.dep_tree/services/dep_tree.js
+++ b/app/js/arethusa.dep_tree/services/dep_tree.js
@@ -31,7 +31,7 @@ angular.module('arethusa.depTree').service('depTree', [
 
     this.externalDependencies = {
       ordered: [
-        "/../../vendor/d3-3.4.13/d3.min.js",
+        "vendor/d3-3.4.13/d3.min.js",
         window.dagred3path
       ]
     };

--- a/deploy_widget.sh
+++ b/deploy_widget.sh
@@ -6,10 +6,27 @@ fi
 echo "Deploying to $deploy_dir"
 
 mkdir -p $deploy_dir/dist
-mkdir -p $deploy_dir/../vendor/d3-3.4.13/
+mkdir -p $deploy_dir/css
+mkdir -p $deploy_dir/fonts
+mkdir -p $deploy_dir/vendor/dagre-d3
+mkdir -p $deploy_dir/vendor/d3-3.4.13
+mkdir -p $deploy_dir/i18n
 
 cp dist/arethusa.min.js $deploy_dir
 cp dist/arethusa.min.map $deploy_dir
 cp dist/arethusa_packages.min.js $deploy_dir/arethusa.packages.min.js
 cp dist/* $deploy_dir/dist
-cp vendor/d3-3.4.13/d3.min.js $deploy_dir/../vendor/d3-3.4.13/d3.min.js
+cp dist/i18n/* $deploy_dir/i18n/
+
+cp vendor/angular-foundation-colorpicker/css/colorpicker.css $deploy_dir/css/colorpicker.css
+cp vendor/font-awesome-4.1.0/css/font-awesome.min.css $deploy_dir/css/font-awesome.min.css
+cp vendor/foundation-icons/foundation-icons.* $deploy_dir/css/
+
+cp vendor/font-awesome-4.1.0/fonts/* $deploy_dir/fonts/
+
+cp app/js/arethusa.widget.loader.js $deploy_dir/arethusa.widget.loader.js
+
+cp vendor/dagre-d3/dagre-d3.min.js $deploy_dir/vendor/dagre-d3/dagre-d3.min.js
+cp vendor/dagre-d3/dagre-d3.min.map $deploy_dir/vendor/dagre-d3/dagre-d3.min.map
+cp vendor/d3-3.4.13/d3.min.js $deploy_dir/vendor/d3-3.4.13/d3.min.js
+cp vendor/angularJS-toaster/toaster.min.map $deploy_dir


### PR DESCRIPTION
Make some small changes to the deployment scripts to make packaging the `widget` branch easier:

* Add a `build` task that cleans and minifies the code without starting a server
* Move the `d3.min.js` file to be within the same directory. This makes it easier to package the code. (It also means making some changes to the Treebank Template code)
* Add more files to the `deploy_widget.sh` script. It should (hopefully) now contain every file needed for the Arethusa widget.