### PR TITLE
Move arethusa.min.css to css directory when deployed

### DIFF
--- a/deploy_widget.sh
+++ b/deploy_widget.sh
@@ -18,6 +18,7 @@ cp dist/arethusa_packages.min.js $deploy_dir/arethusa.packages.min.js
 cp dist/* $deploy_dir/dist
 cp dist/i18n/* $deploy_dir/i18n/
 
+mv $deploy_dir/dist/arethusa.min.css $deploy_dir/css/arethusa.min.css
 cp vendor/angular-foundation-colorpicker/css/colorpicker.css $deploy_dir/css/colorpicker.css
 cp vendor/font-awesome-4.1.0/css/font-awesome.min.css $deploy_dir/css/font-awesome.min.css
 cp vendor/foundation-icons/foundation-icons.* $deploy_dir/css/


### PR DESCRIPTION
Instead if placing `arethusa.min.css` in the `dist/` directory of the deployed application, place it in the `css/` directory with the other CSS.

See discussion here: https://github.com/perseids-publications/treebank-template/pull/29#discussion_r424026981