### PR TITLE
Sponsor links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://www.paypal.me/alpheiosproject", "https://tuftsgiving.org/giving-form.html?id=7&showarea=AR001037&areaid=601&recurring=true"]


### PR DESCRIPTION
Configure GitHub's sponsorship button to have donation links for Alpheios and Perseids.