### PR TITLE
Give tree-settings div the correct height

### DIFF
--- a/app/css/_arethusaMain.scss
+++ b/app/css/_arethusaMain.scss
@@ -81,7 +81,8 @@ html, body {
 }
 
 .tree-settings {
-  margin: 0.3rem;
+  padding: 0.3rem;
+  overflow: auto;
 }
 
 .tree-focus-trigger-controls {


### PR DESCRIPTION
Fixes https://github.com/alpheios-project/arethusa/issues/820

There is an issue with the `dep_tree_no_selector.html` template where the tree overflows the bounding box.

This is caused by the `.tree-settings` div technically having a height of `0` because its children are all floats. Since it doesn't have any height, but its children have a height, there is some weird interaction in a nested svg element that has its own height set to `100%`. The margin of `0.3rem` seems to have the same effect, where it's pushing the svg down but isn't being included in the height calculation of the div.

By changing margin to padding and setting overflow to auto (for [complicated reasons](https://stackoverflow.com/questions/9943503/why-does-css2-1-define-overflow-values-other-than-visible-to-establish-a-new-b/11854515#11854515), overflow auto gives the container div the height of its float), the `.tree-settings` div gets the correct height which fixes the problem.

It's possible this will have other side effects, but I did test the new version with the Treebank Template (using both `dep_tree_no_selector` and `dep_tree`) and everything seems to work.

Also see the [before](https://github.com/perseids-tools/arethusa-widget/blob/4c9f9fdfcabfac50e83a96a16c42c68bdb4de3d2/test/backstop_data/bitmaps_reference/demo_Arethusa_renders_0_document_0_phone.png) and [after](https://github.com/perseids-tools/arethusa-widget/blob/1a438285ca5e4377e16580073ac7cb3e3a5d7aa9/test/backstop_data/bitmaps_reference/demo_Arethusa_renders_0_document_0_phone.png) snapshots adding this commit to the `arethusa-widget` repository.