### PR TITLE
Display tree if comments not configured

### DIFF
--- a/app/js/arethusa.comments/services/comments.js
+++ b/app/js/arethusa.comments/services/comments.js
@@ -54,11 +54,16 @@ angular.module('arethusa.comments').service('comments', [
     function retrieveComments() {
       self.comments = [];
       self.docLevelComments = [];
-      retriever.getData(navigator.status.currentIds[0], function(comments) {
-        self.comments = comments;
-        self.docLevelComments = retriever.docLevelComments();
-        createIndices();
-      });
+
+      // In some cases the retriever is not configured but we still want to
+      // be able to display the tree without crashing.
+      if (retriever) {
+        retriever.getData(navigator.status.currentIds[0], function(comments) {
+          self.comments = comments;
+          self.docLevelComments = retriever.docLevelComments();
+          createIndices();
+        });
+      }
     }
 
     function createIndices() {


### PR DESCRIPTION
If the comments plugin is not configured in the global config, but the treebank XML has a config type that requires comments (e.g. `config="pedalion"`), then the tree fails to display with the error:

```
Error: can't access property "getData", w is undefined
```

This PR fixes the error by wrapping the `w.getData()` call with `if (w) { ... }` so that the tree is still displayed.